### PR TITLE
BN->IDA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # Binary Ninja Importer
-Utility for importing analysis information into Binary Ninja.  The only currently supported mechanism is from IDA. This utility has two parts:
-1. An exporter script which runs on the tool you wish to pull analysis information from. This tool writes a .json file to disk that can be consumed by the importer.
-2. A Binary Ninja plugin which imports the exported information.
 
+Utility for transfering analysis information between Binary Ninja and IDA pro. This utility has four parts:
+1. An IDA plugin that exports analysis data to a json file
+2. A Binary Ninja plugin/script that imports the analysis data that has been exported from IDA
+3. A Binary Ninja plugin/script that exports analysis data to a json file
+4. An IDA plugin that imports analysis data that has been exported from Binary Ninja
 
 ## Usage
 
-Install the `binja_import.py` script into your Binary Ninja user directory. https://docs.binary.ninja/getting-started/index.html#user-folder
+Install the `binja_import.py` and `binja_export.py` scripts into your Binary Ninja user directory. https://docs.binary.ninja/getting-started/index.html#user-folder
 
-Open IDA (this script was only tested in IDA 6.9) Click `File->Script File` and select the `ida_export.py` script. The script will prompt you for a filename to write the export information to.
+### IDA->Binary Ninja
 
-## Supported Analysis data
+1. Open your IDA database
+2. Click `File->Script File` and select the `ida_export.py`
+3. Input the filename of the file you want to write the exported data to
+4. Click Ok. Analysis data will be written to the json file.
+5. Open your BN database for the same binary
+6. Click `tools->Import data to BN`
+7. Enter the file path to the json file
+8. Click ok. Your database will then be updated with the analysis data from IDA.
+
+#### Supported Analysis data
 
 1. Function
     start address
@@ -20,13 +31,26 @@ Open IDA (this script was only tested in IDA 6.9) Click `File->Script File` and 
     string objects (start, length, type)
     string cross-references
 
-## Unsupported Analysis data
+#### Unsupported Analysis data
 
 1. Segments
 2. Global non-string data
 3. Local variable names and types
 4. Standard types and enumerations
 5. Non-function comments (currently unsupported by Binary Ninja)
+
+### Binary Ninja->IDA
+
+1. Open your Binary Ninja database
+2. Click `tools->Export data from BN`
+3. Enter the filename of the file you want to write the exported data to
+4. Click Ok. Analysis data will be written to the json file
+5. Open your IDA database for the same binary
+6. Click `File->Script File` and select the `ida_import.py`
+7. Select the json file
+8. Click ok. Your database will then be updated with the analysis data from BN.
+
+Analysis data for IDA to Binary Ninja is currently limited to comments and symbol names.
 
 ## Notes
 

--- a/binja_export.py
+++ b/binja_export.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#  Copyright (c) 2018 zznop
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import json
+from optparse import OptionParser
+from binaryninja import *
+import sys
+
+def get_functions(bv):
+    """Populate dictionary with function names and offsets
+    """
+    functions = {}
+    for func in bv.functions:
+        functions[func.start] = func.name
+    return functions
+
+def get_symbols(bv):
+    """Populate dictionary of symbol names
+    """
+    symbols = bv.get_symbols()
+    for symbol in symbols:
+        print symbol.name
+
+
+def populate_json_array(bv):
+    """Construct json array of everything we want to export
+    """
+    json_array              = {}
+    json_array["functions"] = get_functions(bv)
+    json_array["names"]     = {}
+    json_array["segments"]  = {}
+    json_array["strings"]   = get_symbols(bv)
+    return json_array
+
+def main():
+    bv = BinaryViewType.get_view_of_file(sys.argv[1])
+    bv.update_analysis_and_wait()
+    json_array = populate_json_array(bv)
+    print json_array
+
+if __name__ == '__main__':
+    main()
+

--- a/binja_export.py
+++ b/binja_export.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-#  Copyright (c) 2018 zznop
+#
+# Copyright (c) 2018 zznop
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -22,10 +23,9 @@
 import json
 from optparse import OptionParser
 from binaryninja import *
-import sys
 
 def get_functions(bv):
-    """Populate dictionary with function names and offsets
+    """Populate dictionary of function names and offsets
     """
     functions = {}
     for func in bv.functions:
@@ -35,27 +35,101 @@ def get_functions(bv):
 def get_symbols(bv):
     """Populate dictionary of symbol names
     """
-    symbols = bv.get_symbols()
-    for symbol in symbols:
-        print symbol.name
+    symbols = {}
+    for symbol in bv.get_symbols():
+        symbols[symbol.address] = symbol.name
+    return symbols
 
+def get_comments(bv):
+    """Populate dictionary of comments
+    """
+    comments = {}
+    for func in bv:
+        for addr in func.comments:
+            comments[addr] = func.get_comment_at(addr)
+    return comments
 
-def populate_json_array(bv):
+def get_sections(bv):
+    """Populate dictionary of sections
+    """
+    sections = {}
+    for section_name in bv.sections:
+        section = bv.get_section_by_name(section_name)
+        sections[section.name] = {
+            'start' : section.start,
+            'end' : section.end
+        }
+
+    return sections
+
+def export_bn(json_file, bv):
     """Construct json array of everything we want to export
     """
     json_array              = {}
-    json_array["functions"] = get_functions(bv)
-    json_array["names"]     = {}
-    json_array["segments"]  = {}
-    json_array["strings"]   = get_symbols(bv)
-    return json_array
+    json_array["sections"]  = get_sections(bv)
+    json_array["names"]     = get_symbols(bv)
+    json_array["comments"]  = get_comments(bv)
 
-def main():
-    bv = BinaryViewType.get_view_of_file(sys.argv[1])
+    try:
+        with open(json_file, "wb") as f:
+            f.write(json.dumps(json_array, indent=4))
+    except Exception as ex:
+        return False, "Failed to create JSON file {} {}".format(json_file, ex)
+
+    return True, None
+
+class GetOptions:
+    def __init__(self, interactive=False):
+        # from BN UI
+        if interactive:
+            json_file = OpenFileNameField("Export json file")
+            get_form_input([json_file], "BN Export Options")
+            if json_file.result == '':
+                self.json_file = None
+            else:
+                self.json_file = json_file.result
+            return 
+
+        # headless
+        usage            = "usage: %prog <bn_database.bndb> <ida_export.json>"
+        parser           = OptionParser(usage=usage)
+        (options, args)  = parser.parse_args()
+        self.bn_database = args[0]
+        self.json_file   = args[1]
+        self.usage       = parser.get_usage()
+
+class ExportBNInBackground(BackgroundTaskThread):
+    def __init__(self, bv, options):
+        global task
+        BackgroundTaskThread.__init__(self, "Exporting data from BN", False)
+        self.json_file = options.json_file
+        self.options   = options
+        self.bv        = bv
+        task           = self
+
+    def run(self):
+        (success, error_message) = export_bn(self.options.json_file, self.bv)
+        if not success:
+            log_error(error_message)
+
+def export_bn_headless():
+    """Export data running as headless script
+    """
+    options = GetOptions(False)
+    bv = BinaryViewType.get_view_of_file(options.bn_database)
     bv.update_analysis_and_wait()
-    json_array = populate_json_array(bv)
-    print json_array
+    (success, error_message) = export_bn(options.json_file, bv)
+    if not success:
+        print "Error: {}".format(error_message)
+
+def export_bn_in_background(bv):
+    """Export data in background from BN UI
+    """
+    options = GetOptions(True)
+    background_task = ExportBNInBackground(bv, options)
+    background_task.start()
 
 if __name__ == '__main__':
-    main()
-
+    export_bn_headless()
+else:
+    PluginCommand.register("Export data from BN", "Export data from BN", export_bn_in_background)

--- a/ida_import.py
+++ b/ida_import.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+# Copyright (c) 2018 zznop
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import idc
+import idautils
+import idaapi
+import json
+
+def sanitize_name(name):
+    """Remove characters from BN names that IDA doesn't like
+    """
+    name = name.replace("!", "_")
+    name = name.replace("@", "_")
+    return name
+
+def import_comments(comments):
+    """Import BN comments
+    """
+    for addr, comment in comments.items():
+        addr = int(addr)
+        comment = comment.encode("utf-8")
+        current_comment = idc.Comment(addr)
+
+        # make a new comment
+        if not current_comment:
+            idc.MakeComm(addr, comment)
+            continue
+
+        # ensure comments hasn't already been imported
+        if comment in current_comment:
+            continue
+
+        # append to comment
+        idc.MakeComm(addr, current_comment + " " + comment)
+
+def import_symbols(names):
+    """Import BN symbol names
+    """
+    for addr, name in names.items():
+        addr = int(addr)
+        name = sanitize_name(name).encode("utf-8")
+        idc.MakeName(addr, name)
+
+def get_json(json_file):
+    """Read JSON data file
+    """
+    json_array = None
+    if json_file is None:
+        print("JSON file not specified")
+        return json_array
+
+    try:
+        f = open(json_file, "rb")
+        json_array = json.load(f)
+    except Exception as e:
+        print("Failed to parse json file {} {}".format(json_file, e))
+    return json_array
+
+def main(json_file):
+    """Import data from BN
+    """
+    json_array = get_json(json_file)
+    if not json_array:
+        return
+
+    import_symbols(json_array["names"])
+    import_comments(json_array["comments"])
+
+if __name__ == "__main__":
+    main(idc.AskFile(1, "*.json", "Import file name"))


### PR DESCRIPTION
This PR contains a Binary Ninja plugin for exporting analysis data (currently limited to comments and symbol names) to a JSON file and an IDA python script for importing the data from the JSON file into an IDA database. I'm adding this feature for teams like mine that have a mixture of IDA and BN users and require collaboration on RE tasks.

I plan on building this out more in the future, but for now it's limited to comments and symbol names. Don't hesitate to criticize/request modification to any changes that you aren't comfortable with.